### PR TITLE
feat: Supported to input commit message

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -64,7 +64,15 @@ export function commandFactory(statusBarItems: MobStatusBarItem[]) {
       }
     }),
     vscode.commands.registerCommand("mob-vscode-gui.next", async () => {
-      const command = "mob next";
+      const commitMessageInput = await vscode.window.showInputBox({
+        title: "Please enter the commit message:",
+        placeHolder: "Enter to ignore",
+      });
+
+      let command = "mob next";
+      if (commitMessageInput !== "") {
+        command = `mob next -m '${commitMessageInput}'`;
+      }
       const expectedMessage = ["git push --no-verify"];
 
       const nextItem = statusBarItems.find((item) => item.id === "next");


### PR DESCRIPTION
Hi. Thank you for creating this useful extension.

When `MOB_REQUIRE_COMMIT_MESSAGE` is set to `true` in the `.mob` file, it requires a commit message. With this configuration, when I press the `Mob Next` button, it displays an error message saying "ERROR commit message required" as shown in the attached image.

![image](https://github.com/remotemobprogramming/mob-vscode-gui/assets/1573290/db3aaba6-5dfd-49e5-b773-c27599784574)

To address this issue, I have added a dialog box where we can input the commit message. Of course, we can also choose to skip it.

![image](https://github.com/remotemobprogramming/mob-vscode-gui/assets/1573290/c3709b28-a6b6-4acd-862c-90dc94c75a64)

What are your thoughts on this change? Thank you!